### PR TITLE
Split the canvas into zones and attempt to find a free zone for a joining bot

### DIFF
--- a/src/paintbots/state.clj
+++ b/src/paintbots/state.clj
@@ -141,8 +141,8 @@
     (if (seq free-zones)
       ;; Put the bot around the middle of a free zone. Add some randomness in the position.
       (let [[min-x min-y max-x max-y] (first free-zones)]
-        {:x (+ min-x (/ (- max-x min-x) 2) (rand-int 5))
-         :y (+ min-y (/ (- max-y min-y) 2) (rand-int 5))})
+        {:x (int (+ min-x (Math/floor (/ (- max-x min-x) 2)) (rand-int 5)))
+         :y (int (+ min-y (Math/floor (/ (- max-y min-y) 2)) (rand-int 5)))})
       ;; No free zones available, return a random position.
       {:x (rand-int canvas-width)
        :y (rand-int canvas-height)})))


### PR DESCRIPTION
This PR will add a feature in the registration phase of a bot.
When a new bot joins, the canvas will be split into separate regions.
The logic then attempts to find a free area that has no bots already.
Finally, the joining bot will be given a coordinate inside a free area
If there are no free areas, the bot will be assigned a random coordinate on the canvas.

This reduces the potential overlap of bots during the registration phase and gives the joining bots more space around them.
